### PR TITLE
Update ct-ng commit hash

### DIFF
--- a/gen-tc.sh
+++ b/gen-tc.sh
@@ -99,25 +99,25 @@ case $1 in
 	kobo)
 		Build_CT-NG \
 			https://github.com/NiLuJe/crosstool-ng.git \
-			efec696101ec01b89ba289a6c4f81cec42e50a45 \
+			390464e718ed2db391019dcbb029df4f7d90ab55 \
 			${CUR_DIR}/configs/ct-ng-kobo-config
 		;;
 	kindlepw2)
 		Build_CT-NG \
 			https://github.com/NiLuJe/crosstool-ng.git \
-			efec696101ec01b89ba289a6c4f81cec42e50a45 \
+			390464e718ed2db391019dcbb029df4f7d90ab55 \
 			${CUR_DIR}/configs/ct-ng-kindlepw2-config
 		;;
 	kindle5)
 		Build_CT-NG \
 			https://github.com/NiLuJe/crosstool-ng.git \
-			efec696101ec01b89ba289a6c4f81cec42e50a45 \
+			390464e718ed2db391019dcbb029df4f7d90ab55 \
 			${CUR_DIR}/configs/ct-ng-kindle5-config
 		;;
 	kindle)
 		Build_CT-NG \
 			https://github.com/NiLuJe/crosstool-ng.git \
-			efec696101ec01b89ba289a6c4f81cec42e50a45 \
+			390464e718ed2db391019dcbb029df4f7d90ab55 \
 			${CUR_DIR}/configs/ct-ng-kindle-config
 		;;
 	*)


### PR DESCRIPTION
Fix a sneaky issue with the Kobo TC, that could lead to binaries that
failed to load on Kobos running glibc 2.19
Could affect a number of C++ apps linking to libstdc++, i.e., sdcv
c.f., https://github.com/koreader/koreader/issues/3302