### PR TITLE
Add support for remarkable toolchain

### DIFF
--- a/gen-tc.sh
+++ b/gen-tc.sh
@@ -79,6 +79,7 @@ Supported platforms:
 	kindlepw2
 	kobo
 	nickel
+	remarkable
 	cervantes
 "
 
@@ -124,6 +125,12 @@ case $1 in
 		Build_CT-NG \
 			https://github.com/NiLuJe/crosstool-ng.git \
 			42586aa50d84870f12244b6c9acdda982e3719ab \
+			"arm-${1}-linux-gnueabi"
+		;;
+	remarkable)
+		Build_CT-NG \
+			https://github.com/tcrs/crosstool-ng.git \
+			37c98916a5695553aba294c5d810226cb88f3193 \
 			"arm-${1}-linux-gnueabi"
 		;;
 	cervantes)

--- a/refs/x-compile.sh
+++ b/refs/x-compile.sh
@@ -332,6 +332,9 @@ case ${1} in
 	mk7 | Mk7 | MK7 )
 		KINDLE_TC="MK7"
 	;;
+	remarkable | reMarkable | Remarkable)
+		KINDLE_TC="remarkable"
+	;;
 	# Or build them?
 	tc )
 		Build_CT-NG-Legacy
@@ -341,7 +344,7 @@ case ${1} in
 		exit 0
 	;;
 	* )
-		echo "You must choose a ToolChain! (k3, k5, pw2, kobo, mk7 or nickel)"
+		echo "You must choose a ToolChain! (k3, k5, pw2, kobo, mk7, nickel or remarkable)"
 		echo "Or, alternatively, ask to build them (tc)"
 		exit 1
 	;;


### PR DESCRIPTION
This just points to my fork of NiLuJe's fork of crosstool-ng to which I've added a remarkable toolchain spec. I just used the Kobo spec and updated the glibc and kernel versions. I've built koreader with the toolchain and it all seems to work on my remarkable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koxtoolchain/20)
<!-- Reviewable:end -->
