### PR TITLE
Upgrade to Ubuntu 22.04 to keep workflows running

### DIFF
--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   toolchain:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   toolchain:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:


### PR DESCRIPTION
Ubuntu 20.04 is now gone so it's been failing. Upgrading to 22.04 will fix this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koxtoolchain/50)
<!-- Reviewable:end -->
