### PR TITLE
ci: add release job

### DIFF
--- a/.github/default_release_notes.md
+++ b/.github/default_release_notes.md
@@ -1,0 +1,13 @@
+Prebuilt versions of the toolchains.
+
+To use them, download the appropriate archive and unpack it in your `${HOME}`,
+so that the toolchain ends up in (here, for `kindlepw2`)
+ `${HOME}/x-tools/arm-kindlepw2-linux-gnueabi`.  Then add `${HOME}/x-tools/*/bin`
+to your `PATH`.
+
+The `x-compile.sh` script included in this repo can do that (and more) for you.
+Using `kindlepw2` as an example toolchain again:
+- if you need a persistent custom sysroot (e.g., if you intend to build a full dependency chain):
+`source ${PWD}/refs/x-compile.sh kindlepw2 env`
+- if you just need a compiler:
+`source ${PWD}/refs/x-compile.sh kindlepw2 env bare`

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -7,7 +7,9 @@ concurrency:
 on: [push, pull_request]
 
 jobs:
+
   toolchain:
+
     runs-on: ubuntu-latest
     container:
       image: koreader/kobase:0.4.0-22.04
@@ -21,7 +23,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Install deps
         run: |
@@ -34,8 +36,44 @@ jobs:
       - name: Tar artifacts
         run: tar -C ~ -czf ${{ matrix.tc }}.tar.gz x-tools
 
-      - name: Uploading artifacts
+      - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.tc }}
           path: ${{ matrix.tc }}.tar.gz
+
+  release:
+
+    if: ${{ !cancelled() && startsWith(github.ref, 'refs/tags/') }}
+    needs: toolchain
+
+    runs-on: ubuntu-latest
+
+    permissions:
+        contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          path: artifacts
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Check if release already exists.
+          gh release list --json name,tagName,isDraft,createdAt,publishedAt | jq --color-output --exit-status --raw-output '.[] | select(.tagName == "${{ github.ref_name }}") | if .tagName == "" then halt_error end' ||
+          # And create it if it does not.
+          gh release create '${{ github.ref_name }}' --draft --notes-file .github/default_release_notes.md --title 'koxtoolchain ${{ github.ref_name }}' --verify-tag
+
+      - name: Upload release artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload '${{ github.ref_name }}' artifacts/* --clobber


### PR DESCRIPTION
Run on tag.

Because download stuff from `git.savannah.gnu.org` is so flaky:
- the release job runs even if some toolchain jobs failed (but not on cancellation)
- a draft release is created

This way it's possible to re-run failed jobs until all artifacts have been uploaded to the release.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koxtoolchain/54)
<!-- Reviewable:end -->
