### PR TITLE
stop using `updatetools`

### DIFF
--- a/gen-tc.sh
+++ b/gen-tc.sh
@@ -67,7 +67,6 @@ Build_CT-NG() {
 			"${ct_ng[@]}" "${tc_target}"
 			"${ct_ng[@]}" oldconfig
 			"${ct_ng[@]}" upgradeconfig
-			"${ct_ng[@]}" updatetools
 			if [ -n "${CI}" ]; then
 				sed -i 's/^CT_LOG_PROGRESS_BAR=y/CT_LOG_PROGRESS_BAR=n/' .config
 			fi


### PR DESCRIPTION
The GNU Savannah servers are really flaky, additionally, unconditionally updating those scripts reduce reproducibility.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koxtoolchain/57)
<!-- Reviewable:end -->
